### PR TITLE
Incluindo width: 100% no conteudo do card #14

### DIFF
--- a/app/views/repository/_card.html.erb
+++ b/app/views/repository/_card.html.erb
@@ -6,7 +6,7 @@
 
     <div>
       <% repository.issues.each do |issue| %>
-        <div class="flex flex-row flex-items-start gap-2 mb-8">
+        <div class="flex flex-row flex-items-start gap-2 mb-8" style="width: 100%;">
           <%= icon issue.issue_type %>
           <div class="flex flex-col">
             <a href="<%= issue.url %>" class="font-size-5 color-black hover-underline no-underline">


### PR DESCRIPTION
Título do Pull Request
Fix: Adiciona width: 100% para uniformizar a lista de issues

Descrição
Problema
A lista de issues no card estava sendo exibida de forma inconsistente, dependendo do tamanho do texto da issue.

Solução
Adicionei width: 100% à <div> que contém cada issue para garantir que a lista seja exibida de forma uniforme, independentemente do tamanho do texto.

PS: esse é o primeiro pull request que faço na vida, espero ter feito certo.